### PR TITLE
Remove version requirements for Python 2.7

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -6,6 +6,3 @@ name = "pypi"
 [packages]
 
 [dev-packages]
-
-[requires]
-python_version = "3.7"


### PR DESCRIPTION
Remove the requirements of python 3 only, otherwise you can't install it via pip:

```
$ python --version
Python 2.7.12
$ pip install argo-model --user
DEPRECATION: Python 2.7 will reach the end of its life on January 1st, 2020. Please upgrade your Python as Python 2.7 won't be maintained after that date. A future version of pip will drop support for Python 2.7. More details about Python 2 support in pip, can be found at https://pip.pypa.io/en/latest/development/release-process/#python-2-support
Collecting argo-model
  ERROR: Could not find a version that satisfies the requirement argo-model (from versions: none)
ERROR: No matching distribution found for argo-model
```